### PR TITLE
Add DPI awareness to manifest (fix #7)

### DIFF
--- a/include/x64.exe.manifest
+++ b/include/x64.exe.manifest
@@ -16,4 +16,12 @@
       language="*" />
   </dependentAssembly>
 </dependency>
+<application>
+  <windowsSettings>
+    <dpiAware xmlns="http://schemas.microsoft.com/SMI/2005/WindowsSettings">true/pm</dpiAware>
+    <!-- legacy -->
+    <dpiAwareness xmlns="http://schemas.microsoft.com/SMI/2016/WindowsSettings">permonitorv2,permonitor</dpiAwareness>
+    <!-- falls back to pm if pmv2 is not available -->
+  </windowsSettings>
+</application>
 </assembly>

--- a/include/x86.exe.manifest
+++ b/include/x86.exe.manifest
@@ -16,4 +16,12 @@
       language="*" />
   </dependentAssembly>
 </dependency>
+<application>
+  <windowsSettings>
+    <dpiAware xmlns="http://schemas.microsoft.com/SMI/2005/WindowsSettings">true/pm</dpiAware>
+    <!-- legacy -->
+    <dpiAwareness xmlns="http://schemas.microsoft.com/SMI/2016/WindowsSettings">permonitorv2,permonitor</dpiAwareness>
+    <!-- falls back to pm if pmv2 is not available -->
+  </windowsSettings>
+</application>
 </assembly>


### PR DESCRIPTION
I tested @roblarky's [suggestion] and found it fixes the DPI issues completely for me. I've marked him as the author since all changes are his, but it would be good to get this into an AltDrag release in the near future 😃 

---

### Testing

[Here's a `.zip` of my build directory][altdrag-fixed-manifest.zip] in case anyone wants to try out these changes without having to compile them.

After extracting, you can either run `AltDrag.exe` directly from the `bin` directory. You can also run the installer (`AltDrag-1.1.exe`), but be sure to manually undo the [workaround] as it will conflict/override these changes.

Alternatively you can of course use [the normal method][build-method] to clone and build this branch if you don't want to trust my binaries.

[suggestion]: https://github.com/stefansundin/altdrag/issues/7#issuecomment-360673051
[workaround]: https://github.com/stefansundin/altdrag/issues/7#issuecomment-314945425
[altdrag-fixed-manifest.zip]: https://github.com/stefansundin/altdrag/files/2719791/altdrag-fixed-manifest.zip
[build-method]: https://stefansundin.github.io/altdrag/doc/build.html