### PR TITLE
Fix infinite loop and .manifest files

### DIFF
--- a/include/tray.c
+++ b/include/tray.c
@@ -45,8 +45,9 @@ int UpdateTray() {
 
   // Only add or modify if not hidden or if balloon will be displayed
   if (!hide || tray.uFlags&NIF_INFO) {
-    // Try until it succeeds, sleep 100 ms between each attempt
-    while (Shell_NotifyIcon((tray_added?NIM_MODIFY:NIM_ADD),&tray) == FALSE) {
+    // Try a few times, sleep 100 ms between each attempt
+    int i=0;
+    while (i++ < 3 && Shell_NotifyIcon((tray_added?NIM_MODIFY:NIM_ADD),&tray) == FALSE) {
       Sleep(100);
     }
     // Success

--- a/include/x64.exe.manifest
+++ b/include/x64.exe.manifest
@@ -1,19 +1,31 @@
 <?xml version="1.0" encoding="UTF-8" standalone="yes"?>
-<assembly xmlns="urn:schemas-microsoft-com:asm.v1" manifestVersion="1.0">
-<assemblyIdentity
-  version="1.0.0.0"
-  processorArchitecture="amd64"
-  name="XP style"
-  type="win32" />
+<assembly xmlns="urn:schemas-microsoft-com:asm.v1" manifestVersion="1.0" xmlns:asmv3="urn:schemas-microsoft-com:asm.v3">
+<assemblyIdentity version="1.0.0.0" processorArchitecture="amd64" name="XP style" type="win32" />
+
 <dependency>
   <dependentAssembly>
-    <assemblyIdentity
-      type="win32"
-      name="Microsoft.Windows.Common-Controls"
-      version="6.0.0.0"
-      processorArchitecture="amd64"
-      publicKeyToken="6595b64144ccf1df"
+    <assemblyIdentity type="win32"
+      name="Microsoft.Windows.Common-Controls" version="6.0.0.0"
+      processorArchitecture="amd64" publicKeyToken="6595b64144ccf1df"
       language="*" />
   </dependentAssembly>
 </dependency>
+
+<asmv3:application>
+  <asmv3:windowsSettings>
+    <dpiAware xmlns="http://schemas.microsoft.com/SMI/2005/WindowsSettings">true</dpiAware>
+    <dpiAwareness xmlns="http://schemas.microsoft.com/SMI/2016/WindowsSettings">PerMonitorV2,PerMonitor</dpiAwareness>
+  </asmv3:windowsSettings>
+</asmv3:application>
+
+<compatibility xmlns="urn:schemas-microsoft-com:compatibility.v1">
+  <application>
+    <supportedOS Id="{8e0f7a12-bfb3-4fe8-b9a5-48fd50a15a9a}"/>
+    <supportedOS Id="{1f676c76-80e1-4239-95bb-83d0f6d0da78}"/>
+    <supportedOS Id="{4a2f28e3-53b9-4441-ba9c-d69d4a4a6e38}"/>
+    <supportedOS Id="{35138b9a-5d96-4fbd-8e2d-a2440225f93a}"/>
+    <supportedOS Id="{e2011457-1546-43c5-a5fe-008deee3d3f0}"/>
+  </application>
+</compatibility>
+
 </assembly>

--- a/include/x86.exe.manifest
+++ b/include/x86.exe.manifest
@@ -1,19 +1,31 @@
 <?xml version="1.0" encoding="UTF-8" standalone="yes"?>
-<assembly xmlns="urn:schemas-microsoft-com:asm.v1" manifestVersion="1.0">
-<assemblyIdentity
-  version="1.0.0.0"
-  processorArchitecture="X86"
-  name="XP style"
-  type="win32" />
+<assembly xmlns="urn:schemas-microsoft-com:asm.v1" manifestVersion="1.0" xmlns:asmv3="urn:schemas-microsoft-com:asm.v3">
+<assemblyIdentity version="1.0.0.0" processorArchitecture="X86" name="XP style" type="win32" />
+
 <dependency>
   <dependentAssembly>
-    <assemblyIdentity
-      type="win32"
-      name="Microsoft.Windows.Common-Controls"
-      version="6.0.0.0"
-      processorArchitecture="X86"
-      publicKeyToken="6595b64144ccf1df"
+    <assemblyIdentity type="win32"
+      name="Microsoft.Windows.Common-Controls" version="6.0.0.0"
+      processorArchitecture="X86" publicKeyToken="6595b64144ccf1df"
       language="*" />
   </dependentAssembly>
 </dependency>
+
+<asmv3:application>
+  <asmv3:windowsSettings>
+    <dpiAware xmlns="http://schemas.microsoft.com/SMI/2005/WindowsSettings">true</dpiAware>
+    <dpiAwareness xmlns="http://schemas.microsoft.com/SMI/2016/WindowsSettings">PerMonitorV2,PerMonitor</dpiAwareness>
+  </asmv3:windowsSettings>
+</asmv3:application>
+
+<compatibility xmlns="urn:schemas-microsoft-com:compatibility.v1">
+  <application>
+    <supportedOS Id="{8e0f7a12-bfb3-4fe8-b9a5-48fd50a15a9a}"/>
+    <supportedOS Id="{1f676c76-80e1-4239-95bb-83d0f6d0da78}"/>
+    <supportedOS Id="{4a2f28e3-53b9-4441-ba9c-d69d4a4a6e38}"/>
+    <supportedOS Id="{35138b9a-5d96-4fbd-8e2d-a2440225f93a}"/>
+    <supportedOS Id="{e2011457-1546-43c5-a5fe-008deee3d3f0}"/>
+  </application>
+</compatibility>
+
 </assembly>


### PR DESCRIPTION
The @MattSturgeon .manifest does not work on XP because of invalid versions declaration this might be an issue for future windows as well (probably not).

This PR also fixes the infinite loop in the tray icon handeling.
This loop leads to AltDrag hanging when changing DPI or going in sleep mode under Win8.x and 10
Fixes: 
https://github.com/stefansundin/altdrag/issues/34, https://github.com/stefansundin/altdrag/issues/76 and https://github.com/stefansundin/altdrag/issues/107
I consider those to be essential fixes that everyone should merge.
